### PR TITLE
Add canary job that runs before matrix jobs

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -28,8 +28,91 @@ on:
                 default: 'latest/edge'
                 required: true
 jobs:
+    canary:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Inspect the system
+              run: |
+                uname -a
+                free -m
+                nproc
+                snap version
+                groups
+                ip addr list
+                ls -l /dev/kvm || true
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Cache downloaded snaps
+              uses: actions/cache@v4
+              with:
+                path: .image-garden/cache-*/snaps
+                key: snaps
+            - name: Cache downloaded virtual machine images
+              uses: actions/cache@v4
+              with:
+                path: ~/snap/image-garden/common/cache/dl
+                key: image-garden-dl-ubuntu-cloud-24.04
+            - name: Cache customized virtual machine images
+              uses: actions/cache@v4
+              with:
+                path: .image-garden
+                key: image-garden-img-ubuntu-cloud-24.04-${{ hashFiles('.image-garden.mk') }}
+            - name: Make permissions on /dev/kvm more lax
+              run: sudo chmod -v 666 /dev/kvm
+            - name: Work around a bug in snapd suspend logic
+              run: |
+                sudo mkdir -p /etc/systemd/system/snapd.service.d
+                echo -e "[Service]\\nEnvironment=SNAPD_STANDBY_WAIT=15m" | sudo tee /etc/systemd/system/snapd.service.d/standby.conf
+                sudo systemctl daemon-reload
+                sudo systemctl restart snapd.service
+            - name: Install image-garden snap
+              run: |
+                export X_SPREAD_SNAP_CACHE_DIR="$(pwd)"/.image-garden/cache-"$(uname -m)"/snaps
+                ./bin/snap-install snapd
+                ./bin/snap-install core24
+                ./bin/snap-install --devmode image-garden "${{ inputs.image-garden-channel || 'latest/edge' }}"
+            - name: Use spread from image-garden snap
+              run: sudo snap alias image-garden.spread spread
+            - name: Restore mtime of .image-garden.mk
+              run: |
+                # Disable man page updates which is time-consuming.
+                echo "set man-db/auto-update false" | sudo debconf-communicate
+                sudo dpkg-reconfigure man-db
+                # Download the deb and install it by hand.
+                wget http://ftp.us.debian.org/debian/pool/main/g/git-mestrelion-tools/git-restore-mtime_2022.12-1_all.deb
+                sudo dpkg -i git-restore-mtime_2022.12-1_all.deb
+                rm -f git-restore-mtime_2022.12-1_all.deb
+                # sudo apt update
+                # sudo apt install -y git-restore-mtime
+                git restore-mtime .image-garden.mk
+            - name: Make the virtual machine image (dry run)
+              run: |
+                ls -lR ~/snap/image-garden/common/cache/dl
+                ls -lR .image-garden
+                image-garden make --debug --dry-run ubuntu-cloud-24.04."$(uname -m)".qcow2
+            - name: Make the virtual machine image
+              run: image-garden make ubuntu-cloud-24.04."$(uname -m)".qcow2 ubuntu-cloud-24.04."$(uname -m)".run ubuntu-cloud-24.04.user-data ubuntu-cloud-24.04.meta-data ubuntu-cloud-24.04.seed.iso
+            - name: Run integration tests
+              run: |
+                export X_SPREAD_SNAPD_CHANEL="${{ inputs.snapd-channel || 'latest/beta' }}"
+                export X_SPREAD_LXD_CHANNEL="${{ inputs.lxd-channel || 'latest/stable' }}"
+                export X_SPREAD_SNAPCRAFT_CHANEL="${{ inputs.snapcraft-channel || 'latest/stable' }}"
+                spread -v garden:ubuntu-cloud-24.04:
+            - name: Show logs
+              if: failure()
+              run: |
+                for f in .image-garden/*.log; do
+                    echo "********************************"
+                    echo "$f"
+                    echo "********************************"
+                    echo
+                    cat "$f"
+                    echo
+                    echo
+                done
     test:
         runs-on: ubuntu-latest
+        needs: canary
         strategy:
             fail-fast: false
             matrix:
@@ -61,8 +144,8 @@ jobs:
                 ls -l /dev/kvm || true
             - name: Checkout code
               uses: actions/checkout@v4
-            - name: Cache downloaded snaps
-              uses: actions/cache@v4
+            - name: Restore cache of downloaded snaps
+              uses: actions/cache/restore@v4
               with:
                 path: .image-garden/cache-*/snaps
                 key: snaps


### PR DESCRIPTION
The implementation is fairly ugly but we can figure something better over time. For the moment this is an improvement.

Fixes: https://github.com/canonical/snapd-smoke-tests/issues/8
Fixes: https://github.com/canonical/snapd-smoke-tests/issues/7