### PR TITLE
Try to avoid racing with concurrent snap-install

### DIFF
--- a/bin/snap-install
+++ b/bin/snap-install
@@ -70,7 +70,13 @@ cd "$X_SPREAD_SNAP_CACHE_DIR"
 
 if [ ! -f "$snap"_"$revision".snap ] || [ ! -f "$snap"_"$revision".assert ]; then
 	echo "Downloading snap $snap revision $revision"
-	snap download "$snap" --revision "$revision"
+	# Download in /var/tmp but then copy to the cache directory.
+	# Hopefully with many racing systems we don't clobber each other.
+	snap download --target-directory=/var/tmp "$snap" --revision "$revision"
+	install -v -m 644 -t "$X_SPREAD_SNAP_CACHE_DIR" /var/tmp/"$snap"_"$revision".assert
+	install -v -m 644 -t "$X_SPREAD_SNAP_CACHE_DIR" /var/tmp/"$snap"_"$revision".snap
+	rm -v -f /var/tmp/"$snap"_"$revision".assert
+	rm -v -f /var/tmp/"$snap"_"$revision".snap
 fi
 
 echo "Installing snap $snap at revision $revision as if it came from channel $channel"


### PR DESCRIPTION
We cannot use flock across virtiofsd reliably and more elaborate schemes are not easy to implement in shell.

The actual download happens in /var/tmp and files are then copied to the shared cache directory. Care is taken to copy just the boring bits and not the fancy SELinux context or other xttrs that are not allowed by our configuration of virtiofs.