### PR TITLE
Exclude canary system from matrix run

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -143,7 +143,8 @@ jobs:
                     - opensuse-cloud-tumbleweed
                     - ubuntu-cloud-20.04
                     - ubuntu-cloud-22.04
-                    - ubuntu-cloud-24.04
+                    # This is duplicating the canary job.
+                    # - ubuntu-cloud-24.04
                     - ubuntu-cloud-25.04
                     - ubuntu-cloud-25.10
         steps:


### PR DESCRIPTION
Fixes: https://github.com/canonical/snapd-smoke-tests/issues/26