### PR TITLE
Stop caching customized images, except for arch

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -169,7 +169,8 @@ jobs:
               with:
                 path: ~/snap/image-garden/common/cache/dl
                 key: image-garden-dl-${{ matrix.system }}
-            - name: Cache customized virtual machine images
+            - name: Cache of customized virtual machine images
+              if: ${{ matrix.system == 'archlinux-cloud' }}
               uses: actions/cache@v4
               with:
                 path: .image-garden


### PR DESCRIPTION
Customized images are pretty large, for some stats:

* image-garden-dl-archlinux-cloud - the vanilla image - 520MB
* image-garden-img-archlinux-cloud-6428500bf91a57077d46452ba0c0ab3612b9e29d9aafb5ad25441ca82a28c26c
  - the customized image - 2.5GB

If we exclude the customized images we can quickly reduce our cache usage significantly.

Fixes: https://github.com/canonical/snapd-smoke-tests/issues/29