### PR TITLE
Set DEBIAN_FRONTEND=noninteractive before calling dpkg-reconfigure

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -81,7 +81,7 @@ jobs:
               run: |
                 # Disable man page updates which is time-consuming.
                 echo "set man-db/auto-update false" | sudo debconf-communicate
-                sudo dpkg-reconfigure man-db
+                sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure man-db
                 # Download the deb and install it by hand.
                 wget http://ftp.us.debian.org/debian/pool/main/g/git-mestrelion-tools/git-restore-mtime_2022.12-1_all.deb
                 sudo dpkg -i git-restore-mtime_2022.12-1_all.deb


### PR DESCRIPTION
Currently this only worked because GitHub uses customized runners where the default prompt behavior is off.