### PR TITLE
Test four variants of LXD (5, 5.21, 6 and latest)

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -12,10 +12,10 @@ on:
                 type: string
                 default: 'latest/beta'
                 required: true
-            lxd-channel:
-                description: 'Store channel of the lxd snap'
+            lxd-risk-level:
+                description: 'Store risk level of the lxd snap'
                 type: string
-                default: 'latest/stable'
+                default: 'candidate'
                 required: true
             snapcraft-channel:
                 description: 'Store channel of the snapcraft snap'
@@ -114,7 +114,7 @@ jobs:
               run: |
                 # Export variables that spread picks up from the host.
                 export X_SPREAD_SNAPD_CHANEL="${{ inputs.snapd-channel || 'latest/beta' }}"
-                export X_SPREAD_LXD_CHANNEL="${{ inputs.lxd-channel || 'latest/stable' }}"
+                export X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}"
                 export X_SPREAD_SNAPCRAFT_CHANEL="${{ inputs.snapcraft-channel || 'latest/stable' }}"
                 # Run integration tests.
                 spread -v garden:ubuntu-cloud-24.04:
@@ -241,7 +241,7 @@ jobs:
               run: |
                 # Export variables that spread picks up from the host.
                 export X_SPREAD_SNAPD_CHANEL="${{ inputs.snapd-channel || 'latest/beta' }}"
-                export X_SPREAD_LXD_CHANNEL="${{ inputs.lxd-channel || 'latest/stable' }}"
+                export X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}"
                 export X_SPREAD_SNAPCRAFT_CHANEL="${{ inputs.snapcraft-channel || 'latest/stable' }}"
                 # Run integration tests.
                 spread -v garden:${{ matrix.system }}:

--- a/spread.yaml
+++ b/spread.yaml
@@ -89,7 +89,7 @@ environment:
     X_SPREAD_CACHE_DIR: /mnt/cache
     X_SPREAD_SNAP_CACHE_DIR: $X_SPREAD_CACHE_DIR/snaps
     X_SPREAD_SNAPD_CHANNEL: '$(HOST: echo "${X_SPREAD_SNAPD_CHANNEL:-latest/beta}")'
-    X_SPREAD_LXD_CHANNEL: '$(HOST: echo "${X_SPREAD_LXD_CHANNEL:-latest/stable}")'
+    X_SPREAD_LXD_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_LXD_CHANNEL:-candidate}")'
     X_SPREAD_SNAPCRAFT_CHANNEL: '$(HOST: echo "${X_SPREAD_SNAPCRAFT_CHANNEL:-latest/stable}")'
 exclude:
     - .image-garden

--- a/tests/server/lxd/task.yaml
+++ b/tests/server/lxd/task.yaml
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Canonical Ltd.
+environment:
+    LXD_TRACK/5: "5.0"
+    LXD_TRACK/5_21: "5.21"
+    LXD_TRACK/6: 6
+    LXD_TRACK/latest: latest
 execute: |
     snap run lxd --help | MATCH 'The LXD container manager'
     snap run lxd.lxc launch ubuntu:24.04 u1
     snap run lxd.lxc exec u1 -- cat /etc/os-release | MATCH 'VERSION_ID="24.04"'
 prepare: |
-    snap-install lxd "${X_SPREAD_LXD_CHANNEL}"
+    snap-install lxd ${LXD_TRACK}/"${X_SPREAD_LXD_RISK_LEVEL}"
     # LXD is not immediately ready to accept API requets.
     snap run lxd waitready
     # Initialize LXD storage and networking with default settings.

--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Canonical Ltd.
+environment:
+    LXD_TRACK/5: "5.0"
+    LXD_TRACK/5_21: "5.21"
+    LXD_TRACK/6: 6
+    LXD_TRACK/latest: latest
 execute: |
     snap run snapcraft --help 2>&1 | MATCH 'Package, distribute, and update snaps for Linux and IoT'
     cd test-snapd-smoke && snapcraft -v
@@ -18,7 +23,7 @@ debug: |
     fi
     cat ~/.local/state/snapcraft/log/snapcraft-*.log || true
 prepare: |
-    snap-install lxd "${X_SPREAD_LXD_CHANNEL}"
+    snap-install lxd ${LXD_TRACK}/"${X_SPREAD_LXD_RISK_LEVEL}"
     # LXD is not immediately ready to accept API requets.
     snap run lxd waitready
     # Initialize LXD storage and networking with default settings.


### PR DESCRIPTION
LXD has a more complex release cycle than just one track and it was suggested that we test more than one release at once. Switch the default LXD risk level to `candidate` and use spread variants to duplicate the tests that use, or rely on, lxd.