### PR TITLE
Add smoke test for MAAS 3.{4,5,6}

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -17,6 +17,11 @@ on:
                 type: string
                 default: 'candidate'
                 required: true
+            maas-risk-level:
+                description: 'Store risk level of the maas snap'
+                type: string
+                default: 'candidate'
+                required: true
             snapcraft-channel:
                 description: 'Store channel of the snapcraft snap'
                 type: string
@@ -118,6 +123,7 @@ jobs:
                 # Export variables that spread picks up from the host.
                 export X_SPREAD_SNAPD_CHANEL="${{ inputs.snapd-channel || 'latest/beta' }}"
                 export X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}"
+                export X_SPREAD_MAAS_RISK_LEVEL="${{ inputs.maas-risk-level || 'candidate' }}"
                 export X_SPREAD_SNAPCRAFT_CHANEL="${{ inputs.snapcraft-channel || 'latest/stable' }}"
                 # Run integration tests.
                 spread -v garden:ubuntu-cloud-24.04:
@@ -248,6 +254,7 @@ jobs:
                 # Export variables that spread picks up from the host.
                 export X_SPREAD_SNAPD_CHANEL="${{ inputs.snapd-channel || 'latest/beta' }}"
                 export X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}"
+                export X_SPREAD_MAAS_RISK_LEVEL="${{ inputs.maas-risk-level || 'candidate' }}"
                 export X_SPREAD_SNAPCRAFT_CHANEL="${{ inputs.snapcraft-channel || 'latest/stable' }}"
                 # Run integration tests.
                 spread -v garden:${{ matrix.system }}:

--- a/spread.yaml
+++ b/spread.yaml
@@ -90,6 +90,7 @@ environment:
     X_SPREAD_SNAP_CACHE_DIR: $X_SPREAD_CACHE_DIR/snaps
     X_SPREAD_SNAPD_CHANNEL: '$(HOST: echo "${X_SPREAD_SNAPD_CHANNEL:-latest/beta}")'
     X_SPREAD_LXD_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_LXD_RISK_LEVEL:-candidate}")'
+    X_SPREAD_MAAS_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_MAAS_RISK_LEVEL:-candidate}")'
     X_SPREAD_SNAPCRAFT_CHANNEL: '$(HOST: echo "${X_SPREAD_SNAPCRAFT_CHANNEL:-latest/stable}")'
 exclude:
     - .image-garden

--- a/spread/allocate.sh
+++ b/spread/allocate.sh
@@ -10,9 +10,9 @@ fi
 # Check which architecture we will run on.
 : "${ARCH:="$(uname -m)"}"
 
-# Give each virtual machine two gigabytes of RAM.
+# Give each virtual machine 2 gigabytes of RAM.
 # Note that this is in sync with the "-object memory-backend" entry below.
-export QEMU_MEM_OPTION='-m 1024'
+export QEMU_MEM_OPTION='-m 2048'
 
 # If we have virtiofsd available then use it to provide efficient cache for each virtual machine.
 if [ -x "${SNAP-}"/usr/libexec/virtiofsd ]; then
@@ -66,7 +66,7 @@ if [ -x "${SNAP-}"/usr/libexec/virtiofsd ]; then
 		"$SPREAD_SYSTEM"."$ARCH" \
 		-chardev socket,id=char0,path="$VIRTIOFSD_SOCK_PATH" \
 		-device vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=spread-cache \
-		-object memory-backend-file,id=mem,size=1G,mem-path="$SHM_PATH",share=on \
+		-object memory-backend-file,id=mem,size=2048M,mem-path="$SHM_PATH",share=on \
 		-numa node,memdev=mem)"; then
 		# Save the PID so that we can kill the poor-man's-service later.
 		echo "$VIRTIOFSD_PID" >.image-garden/vhostqemu."$ADDR".pid

--- a/tests/server/maas/task.yaml
+++ b/tests/server/maas/task.yaml
@@ -13,7 +13,7 @@ execute: |
     printf "Waiting for MAAS to be up and running.."
     sleep 15
     while true; do
-        status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5240/MAAS/api/2.0/describe/)
+        status="$(timeout 5s curl -s -o /dev/null -w "%{http_code}" http://localhost:5240/MAAS/api/2.0/describe/)"
         if [ "$status" -eq 200 ]; then
             echo "Server is up! (HTTP 200)"
             break

--- a/tests/server/maas/task.yaml
+++ b/tests/server/maas/task.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+environment:
+    MAAS_TRACK/3_6: "3.6"
+    MAAS_TRACK/3_5: "3.5"
+    MAAS_TRACK/3_4: "3.4"
+execute: |
+    snap run maas --help | MATCH 'usage: maas \[-h\] COMMAND \.\.\.'
+    # Initialize maas and connect it to the test database.
+    snap run maas init region+rack --database-uri maas-test-db:///  --maas-url http://localhost:5240/MAAS
+    snap run maas createadmin --username admin --password admin --email admin@example.com
+    # See if it is alive.
+    printf "Waiting for MAAS to be up and running.."
+    sleep 15
+    while true; do
+        status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5240/MAAS/api/2.0/describe/)
+        if [ "$status" -eq 200 ]; then
+            echo "Server is up! (HTTP 200)"
+            break
+        else
+            echo "Waiting... (HTTP $status)"
+            sleep 2
+        fi
+    done
+prepare: |
+    snap-install maas-test-db ${MAAS_TRACK}/"${X_SPREAD_MAAS_RISK_LEVEL}"
+    snap-install maas ${MAAS_TRACK}/"${X_SPREAD_MAAS_RISK_LEVEL}"
+restore: |
+    snap remove --purge maas
+    snap remove --purge maas-test-db
+summary: Install and see Metal-As-A-Service (MAAS) help output.


### PR DESCRIPTION
The test installs maas from the tested tracks (3.4, 3.5 and 3.6) and parametric stability level X_SPREAD_MAAS_RISK_LEVEL, and runs the command `maas --help`.