### PR TITLE
Run spread only when relevant files change

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -5,6 +5,12 @@ on:
     push:
         branches: ["main"]
     pull_request:
+        paths:
+            - '.github/workflows/spread.yaml'
+            - 'bin/*'
+            - 'spread.yaml'
+            - 'spread/*.sh'
+            - 'tests/**'
     workflow_dispatch:
         inputs:
             snapd-channel:


### PR DESCRIPTION
Apart from test files, the workflow file and test tools all trigger the workflow on a pull request.