### PR TITLE
Add support for openSUSE Tumblweed with SELinux

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -171,6 +171,7 @@ jobs:
                     - fedora-cloud-41
                     - fedora-cloud-42
                     - opensuse-cloud-tumbleweed
+                    - opensuse-cloud-tumbleweed-apparmor
                     - ubuntu-cloud-20.04
                     - ubuntu-cloud-22.04
                     # This is duplicating the canary job.

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -100,9 +100,6 @@ $(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
 $(snapd_suspend_workaround)
 # https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
 - echo net.ipv4.conf.all.forwarding=1 >/etc/sysctl.d/99-forwarding.conf
-# Tumbleweed is now using SELinux. Switch it back to AppArmor
-- sed -i -e 's/security=selinux/security=apparmor/g' /etc/default/grub
-- update-bootloader
 # Add the system:snappy repository and install snapd
 - zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed snappy
 - zypper --gpg-auto-import-keys refresh
@@ -134,6 +131,52 @@ $(snapd_suspend_workaround)
     if snap list snapd | grep -q snapd; then
         snap remove --purge snapd
     fi
+packages:
+- curl
+- jq
+endef
+
+# XXX: small hack to offer two versions of openSUSE Tumbleweed.
+
+opensuse-cloud-tumbleweed-apparmor.x86_64.run: $(MAKEFILE_LIST) | opensuse-cloud-tumbleweed-apparmor.x86_64.qcow2 opensuse-cloud-tumbleweed.x86_64.efi-code.img opensuse-cloud-tumbleweed.x86_64.efi-vars.img
+	echo "#!/bin/sh" >$@
+	echo 'set -xeu' >>$@
+	echo "# WARNING: The .qcow2 file refers to a file in $(GARDEN_DL_DIR)/opensuse" >>$@
+	echo '$(strip $(call QEMU_SYSTEM_X86_64_EFI_CMDLINE,$(word 1,$|),$(word 2,$|),$(word 3,$|)) "$$@")' >>$@
+	chmod +x $@
+
+opensuse-cloud-tumbleweed-apparmor.x86_64.qcow2: $(GARDEN_DL_DIR)/opensuse/opensuse-cloud-tumbleweed.x86_64.qcow2 opensuse-cloud-tumbleweed-apparmor.x86_64.seed.iso opensuse-cloud-tumbleweed-apparmor.x86_64.efi-code.img opensuse-cloud-tumbleweed-apparmor.x86_64.efi-vars.img
+	$(strip $(QEMU_IMG) create -f qcow2 -b $< -F qcow2 $@ $(QEMU_IMG_SIZE))
+	$(strip $(call QEMU_SYSTEM_X86_64_EFI_CMDLINE,$@,$(word 3,$^),$(word 4,$^)) \
+    -drive file=$(word 2,$^),format=raw,id=drive1,if=none,readonly=true,media=cdrom \
+    -device virtio-blk,drive=drive1 \
+    | tee $@.log)
+
+opensuse-cloud-tumbleweed-apparmor.x86_64.meta-data: export META_DATA = $(call CLOUD_INIT_META_DATA_TEMPLATE,opensuse)
+opensuse-cloud-tumbleweed-apparmor.x86_64.meta-data: $(MAKEFILE_LIST)
+	echo "$${META_DATA}" | tee $@
+	touch --reference=$(shell stat $^ -c '%Y %n' | sort -nr | cut -d ' ' -f 2 | head -n 1) $@
+
+opensuse-cloud-tumbleweed-apparmor.x86_64.user-data: export USER_DATA = $(call $(call PICK_CLOUD_INIT_USER_DATA_TEMPLATE_FOR,OPENSUSE,tumbleweed-apparmor),opensuse-tumbleweed,opensuse)
+opensuse-cloud-tumbleweed-apparmor.x86_64.user-data: $(MAKEFILE_LIST) $(wildcard $(GARDEN_PROJECT_DIR)/.image-garden.mk)
+	echo "$${USER_DATA}" | tee $@
+	touch --reference=$(shell stat $^ -c '%Y %n' | sort -nr | cut -d ' ' -f 2 | head -n 1) $@
+
+define OPENSUSE_tumbleweed-apparmor_CLOUD_INIT_USER_DATA_TEMPLATE
+$(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
+$(snapd_suspend_workaround)
+# https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+- echo net.ipv4.conf.all.forwarding=1 >/etc/sysctl.d/99-forwarding.conf
+# Tumbleweed is now using SELinux. Switch it back to AppArmor
+- sed -i -e 's/selinux=1//' -e 's/security=selinux/security=apparmor/g' /etc/default/grub
+- update-bootloader
+# Add the system:snappy repository and install snapd
+- zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed snappy
+- zypper --gpg-auto-import-keys refresh
+- zypper dup --from snappy
+- zypper install -y snapd
+- systemctl enable --now snapd
+- systemctl enable --now snapd.apparmor
 packages:
 - curl
 - jq

--- a/spread.yaml
+++ b/spread.yaml
@@ -69,6 +69,11 @@ backends:
                 password: root
                 username: root
                 workers: 2
+            - opensuse-cloud-tumbleweed-apparmor:
+                manual: true
+                password: root
+                username: root
+                workers: 2
             - archlinux-cloud:
                 manual: true
                 password: root


### PR DESCRIPTION
The code in .image-garden.mk is a bit of a hack until upstream tag/variant feature comes along.