### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -161,6 +161,7 @@ jobs:
             fail-fast: false
             matrix:
                 system:
+                    - amazonlinux-cloud-2
                     - amazonlinux-cloud-2023
                     - archlinux-cloud
                     - centos-cloud-10

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -35,7 +35,30 @@ packages:
 - git
 endef
 
-define AMAZONLINUX_CLOUD_INIT_USER_DATA_TEMPLATE
+define AMAZONLINUX_2_CLOUD_INIT_USER_DATA_TEMPLATE
+$(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
+$(snapd_suspend_workaround)
+# https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+- echo net.ipv4.conf.all.forwarding=1 >/etc/sysctl.d/99-forwarding.conf
+- systemctl enable --now snapd.socket
+# Amazon 2 does not implement the power_state cloud-init plugin.
+- shutdown --poweroff now
+packages:
+# Curl is pre-installed but only in the "minimal" version.
+# Installing curl via cloud-init fails as it conflicts with curl-minimal
+- jq
+# Ensure that snapd is installed.
+- snapd
+# Snapd is distributed via Maciej's quasi-official archive.
+yum_repos:
+  snapd:
+    name: snapd packages for Amazon Linux
+    baseurl: https://bboozzoo.github.io/snapd-amazon-linux/amzn2/$$basearch
+    gpgcheck: false
+    enabled: true
+endef
+
+define AMAZONLINUX_2023_CLOUD_INIT_USER_DATA_TEMPLATE
 $(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
 $(snapd_suspend_workaround)
 # https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker

--- a/spread.yaml
+++ b/spread.yaml
@@ -74,6 +74,11 @@ backends:
                 password: root
                 username: root
                 workers: 2
+            - amazonlinux-cloud-2:
+                manual: true
+                password: root
+                username: root
+                workers: 2
             - amazonlinux-cloud-2023:
                 manual: true
                 password: root


### PR DESCRIPTION
This is relatively straightforward except for the addition of a workaround that allows cloud-init to shut down the system after preparation done during first boot.