### PR TITLE
Add test suite checking how snapd can be purged

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -21,8 +21,8 @@ define ARCHLINUX_CLOUD_INIT_USER_DATA_TEMPLATE
 $(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
 $(snapd_suspend_workaround)
 # We cannot build the package as root so switch to the archlinux user.
-- sudo -u archlinux git clone https://aur.archlinux.org/snapd.git /tmp/snapd
-- cd /tmp/snapd && sudo -u archlinux makepkg -si --noconfirm
+- sudo -u archlinux git clone https://aur.archlinux.org/snapd.git /var/tmp/snapd
+- cd /var/tmp/snapd && sudo -u archlinux makepkg -si --noconfirm
 - systemctl enable --now snapd.socket
 - systemctl enable --now snapd.apparmor.service
 # https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
@@ -108,8 +108,8 @@ $(snapd_suspend_workaround)
 - zypper --gpg-auto-import-keys refresh
 - zypper dup --from snappy
 - zypper install -y snapd
-- systemctl enable --now snapd
-- systemctl enable --now snapd.apparmor
+- systemctl enable --now snapd.socket
+- systemctl enable --now snapd.apparmor.service
 packages:
 - curl
 - jq

--- a/spread.yaml
+++ b/spread.yaml
@@ -97,11 +97,21 @@ exclude:
     - .image-garden
     - .git
 path: /root/snapd-smoke-tests
-prepare: exec ./spread/prepare.sh
+prepare: exec "$SPREAD_PATH"/spread/prepare.sh
 project: snapd-smoke-tests
-restore: exec ./spread/restore.sh
+restore: exec "$SPREAD_PATH"/spread/restore.sh
 suites:
     tests/desktop/:
         summary: Desktop test suite (alpha)
     tests/server/:
         summary: Server test suite (beta)
+    tests/purge/:
+        systems:
+            # The following distributions do not have a maintenance script
+            # so removing snapd while snaps are installed, breaks things.
+            - -archlinux-cloud
+            - -opensuse-cloud-tumbleweed
+        summary: Classic packag purge tests (alpha)
+        prepare-each: exec "$SPREAD_PATH"/spread/purge-suite-prepare-each.sh
+        restore-each: exec "$SPREAD_PATH"/spread/purge-suite-restore-each.sh
+        restore: exec "$SPREAD_PATH"/spread/purge-suite-restore.sh

--- a/spread/install-snapd-and-bases.sh
+++ b/spread/install-snapd-and-bases.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+set -xeu
+
+# Ensure that installing snaps with classic confinement is allowed.
+if [ ! -e /snap ] && [ -d /var/lib/snapd/snap ]; then
+	ln -s /var/lib/snapd/snap /snap
+fi
+
+# Pre-install snapd as a snap. Use the latest/beta channel
+# to always test upcoming updates.
+snap-install snapd latest/"${X_SPREAD_SNAPD_RISK_LEVEL}"
+
+# Pre-install all the base snaps.
+for snap in bare core core18 core20 core22 core24; do
+	snap-install "$snap"
+done

--- a/spread/prepare.sh
+++ b/spread/prepare.sh
@@ -34,19 +34,4 @@ mkdir "$X_SPREAD_CACHE_DIR"
 # performance.
 mount -t virtiofs spread-cache "$X_SPREAD_CACHE_DIR" || true
 
-# Ensure that installing snaps with classic confinement is allowed.
-if [ -d /var/lib/snapd/snap ]; then
-	ln -s /var/lib/snapd/snap /snap
-fi
-
-# Pre-install snapd as a snap. Use the latest/beta channel
-# to always test upcoming updates.
-snap-install snapd latest/"${X_SPREAD_SNAPD_RISK_LEVEL}"
-
-# Show the version of snapd-as-a-snap packaged snapd.
-snap version | tee snap-version.snap.debug
-
-# Pre-install all the base snaps.
-for snap in bare core core18 core20 core22 core24; do
-	snap-install "$snap"
-done
+exec "$SPREAD_PATH"/spread/install-snapd-and-bases.sh

--- a/spread/purge-suite-prepare-each.sh
+++ b/spread/purge-suite-prepare-each.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+set -xeu
+# See the comment in purge-suite-restore.sh for explanation as to why we need
+# to re-install snapd in the prepare-each step.
+if [ -n "$(command -v apt)" ]; then
+	apt install -y snapd
+elif [ -n "$(command -v dnf)" ]; then
+	dnf install -y snapd
+elif [ -n "$(command -v yum)" ]; then
+	yum install -y snapd
+elif [ -n "$(command -v zypper)" ]; then
+	zypper install -y snapd
+elif [ -n "$(command -v pacman)" ]; then
+	pacman --noconfirm -U /var/tmp/snapd/snapd-*.tar.zst
+else
+	echo "How do I re-install snapd on this system? $(cat /etc/os-release)"
+	exit 1
+fi
+systemctl enable --now snapd.socket
+if [ -f /usr/lib/systemd/system/snapd.apparmor.service ]; then
+	systemctl enable --now snapd.apparmor.service
+fi
+snap wait system seed.loaded
+
+exec "$SPREAD_PATH"/spread/install-snapd-and-bases.sh

--- a/spread/purge-suite-restore-each.sh
+++ b/spread/purge-suite-restore-each.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+set -xeu
+
+# The restore-each step is unorthodox in the sense that it does not restore but
+# rather, contains the property we care about measuring - it purges snapd from
+# the system using the classic packaging system.
+if [ -n "$(command -v apt)" ]; then
+	apt remove --purge -y snapd
+elif [ -n "$(command -v dnf)" ]; then
+	dnf remove -y snapd
+elif [ -n "$(command -v yum)" ]; then
+	yum remove -y snapd
+elif [ -n "$(command -v zypper)" ]; then
+	zypper remove -y snapd
+elif [ -n "$(command -v pacman)" ]; then
+	pacman --noconfirm -R snapd
+else
+	echo "How do I uninstall snapd on this system? $(cat /etc/os-release)"
+	exit 1
+fi

--- a/spread/purge-suite-restore.sh
+++ b/spread/purge-suite-restore.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+set -xeu
+# The "purge" suite purges the classic snapd package in the restore-each step,
+# trying to observe that snaps that are installed by specific tasks can indeed
+# be purged correctly.
+#
+# This is somewhat unusual for restore, so the suite-level restore actually
+# does the work necessary for restore - re-install snapd the classic package.
+#
+# Notably we have to do this because spread does not offer stable order of
+# execution so it is possible that purge jobs will run first, and then other
+# suite will start running. We must leave the system in the same state as we
+# started.
+exec "$SPREAD_PATH"/spread/purge-suite-prepare-each.sh

--- a/tests/purge/docker/public_html/index.txt
+++ b/tests/purge/docker/public_html/index.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+Hello World

--- a/tests/purge/docker/task.yaml
+++ b/tests/purge/docker/task.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+summary: See if snapd can be purged while Docker is used.
+details: |
+    The Docker snap is one of the most complex snaps known to exist, largely
+    due to the fact that it is privileged and can break out of the sandbox to
+    perform many of the more advanced functions. Removing Docker correctly is
+    tricky, especially when snapd itself is being removed and all we have is
+    the distribution maintainer script.
+prepare: |
+    snap-install docker latest/"$X_SPREAD_DOCKER_RISK_LEVEL"
+    # Give docker a moment to expose the API surface.
+    for _ in $(seq 5); do
+        if [ -S /var/run/docker.sock ]; then
+            break
+        fi
+        sleep 1
+    done
+    # Launch a container that runs in the background.
+    snap run docker run -v ./public_html:/usr/share/nginx/html:ro -d -p 8080:80 nginx
+    for _ in $(seq 5); do
+        if curl http://localhost:8080/index.txt | grep 'Hello World'; then
+            break
+        fi
+        sleep 1
+    done
+    curl http://localhost:8080/index.txt | MATCH 'Hello World'

--- a/tests/purge/firefox/task.yaml
+++ b/tests/purge/firefox/task.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+summary: See if snapd can be purged while Firefox is installed.
+details: |
+    The Firefox snap uses mount-control interface to establish a connection to
+    spell checker database offered by the host. As of snapd 2.70, this is not
+    tracked by very well and may leak after the snapd package is removed from
+    the system.
+prepare: |
+    snap-install gnome-42-2204
+    snap-install gtk-common-themes
+    snap-install firefox
+# TODO: I wonder if we can check that the mount-control mount point
+# is removed. This is a known issue in current snapd.

--- a/tests/purge/hello/task.yaml
+++ b/tests/purge/hello/task.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+summary: See if snapd can be purged while hello snap is installed.
+details: |
+    The hello snap is extremely basic and removing it should be equally easy.
+    This test serves as the smoke test for the behavior of the snapd classic
+    package maintenance scripts.
+prepare: |
+    snap-install hello

--- a/tests/purge/lxd/task.yaml
+++ b/tests/purge/lxd/task.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+summary: See if snapd can be purged while LXD is used.
+details: |
+    The LXD snap is one of the most complex snaps known to exist, largely due
+    to the fact that it is privileged and can break out of the sandbox to
+    perform many of the more advanced functions. Removing LXD correctly is
+    tricky, especially when snapd itself is being removed and all we have is
+    the distribution maintainer script.
+environment:
+    LXD_TRACK/5: "5.0"
+    LXD_TRACK/5_21: "5.21"
+    LXD_TRACK/6: 6
+    LXD_TRACK/latest: latest
+prepare: |
+    snap-install lxd ${LXD_TRACK}/"${X_SPREAD_LXD_RISK_LEVEL}"
+    # LXD is not immediately ready to accept API requets.
+    snap run lxd waitready
+    # Initialize LXD storage and networking with default settings.
+    snap run lxd init --auto
+    # Start a LXD container so that there's something interesting going on while we attempt to purge snapd.
+    snap run lxd --help | MATCH 'The LXD container manager'
+    snap run lxd.lxc launch ubuntu:24.04 u1
+    snap run lxd.lxc exec u1 -- cat /etc/os-release | MATCH 'VERSION_ID="24.04"'

--- a/tests/purge/only-base-snaps-and-snapd/task.yaml
+++ b/tests/purge/only-base-snaps-and-snapd/task.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+summary: See if snapd can be purged while only base snaps are installed
+details: |
+    The restore-each step of this suite purges the snapd classic package.
+    In this test we do not install any difficult snaps, so only base snaps
+    and snapd itself is installed as a snap.
+execute: |
+    snap list | MATCH snapd
+    snap list | MATCH core
+    snap list | MATCH core18
+    snap list | MATCH core20
+    snap list | MATCH core22
+    snap list | MATCH core24
+    snap list | MATCH bare


### PR DESCRIPTION
The test suite uses an unusual arrangement where prepare-each and suite restore both install snapd and base snaps, restore-each *purges* the snapd classic package. This leaves the actual tests to prepare the stage for the test by installing snaps. Tests range from installing hello-world style snaps all the way to installing the archetype of complex snap integration - LXD snap with running containers.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35142