### PR TITLE
Add support for testing CI/CD builds from Salsa

### DIFF
--- a/.github/workflows/salsa.yaml
+++ b/.github/workflows/salsa.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+name: salsa
+on:
+    workflow_dispatch:
+        inputs:
+            salsa-job-id:
+                description: 'ID of the CI/CD the "build" job at https://salsa.debian.org/debian/snapd which contains Debian package to test'
+                type: string
+                required: true
+            snapd-risk-level:
+                description: 'Store risk level of the snapd snap'
+                type: string
+                default: 'beta'
+                required: true
+            lxd-risk-level:
+                description: 'Store risk level of the LXD snap'
+                type: string
+                default: 'candidate'
+                required: true
+            maas-risk-level:
+                description: 'Store risk level of the MAAS snap'
+                type: string
+                default: 'candidate'
+                required: true
+            snapcraft-risk-level:
+                description: 'Store risk level of the snapcraft snap'
+                type: string
+                default: 'stable'
+                required: true
+            docker-risk-level:
+                description: 'Store risk level of the docker snap'
+                type: string
+                default: stable
+            image-garden-channel:
+                description: 'Store channel of the image-garden snap'
+                type: string
+                default: 'latest/edge'
+                required: true
+jobs:
+    spread:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              # This is essential for git restore-mtime to work correctly.
+              with:
+                fetch-depth: 0
+            - name: Cache downloaded snaps
+              uses: actions/cache@v4
+              with:
+                path: .image-garden/cache-*/snaps
+                key: snaps
+            - name: Set environment variables for spread
+              run: |
+                # Export variables that spread picks up from the host.
+                echo X_SPREAD_SNAPD_RISK_LEVEL="${{ inputs.snapd-risk-level || 'beta' }}" >> $GITHUB_ENV
+                echo X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_MAAS_RISK_LEVEL="${{ inputs.maas-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_SNAPCRAFT_RISK_LEVEL="${{ inputs.snapcraft-risk-level || 'stable' }}" >> $GITHUB_ENV
+                echo X_SPREAD_DOCKER_RISK_LEVEL="${{ inputs.docker-risk-level || 'stable' }}" >> $GITHUB_ENV
+                echo X_SPREAD_SALSA_JOB_ID="${{ inputs.salsa-job-id || '' }}" >> $GITHUB_ENV
+            - name: Run integration tests
+              uses: zyga/image-garden-action@85a3d79c9d1e1628d7b0bad081b3a3463c2819a3
+              with:
+                garden-system: debian-cloud-sid
+                image-garden-channel: ${{ inputs.image-garden-channel }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -68,6 +68,7 @@ jobs:
               uses: zyga/image-garden-action@85a3d79c9d1e1628d7b0bad081b3a3463c2819a3
               with:
                 garden-system: ubuntu-cloud-24.04
+                image-garden-channel: ${{ inputs.image-garden-channel }}
     test:
         runs-on: ubuntu-latest
         needs: canary
@@ -114,5 +115,6 @@ jobs:
             - name: Run integration tests
               uses: zyga/image-garden-action@85a3d79c9d1e1628d7b0bad081b3a3463c2819a3
               with:
+                image-garden-channel: ${{ inputs.image-garden-channel }}
                 garden-system: ${{ matrix.garden-system }}
                 cache-prepared-images: ${{ matrix.garden-system == 'archlinux-cloud' }}

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -101,6 +101,7 @@ $(snapd_suspend_workaround)
 packages:
 - curl
 - jq
+- unzip
 # Ensure that snapd is installed.
 - snapd
 endef

--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ To run tests locally install the `image-garden` snap and then run the
 `run-spread.sh` script from the root of the project. For optimal performance
 you may need to use _edge_ channel for both snapd snap and image-garden until
 image-garden 0.4 and snapd 2.71 are released.
+
+## Testing builds from salsa.debian.org
+
+Grab the GitLab job ID for the "build" job of a pipeline that ran on
+https://salsa.debian.org/debian/snapd and either invoke the GitHub workflow
+"salsa", passing to it the ID or run spread locally with
+`X_SPREAD_SALSA_JOB_ID=` environment variable set.
+
+Note that this is only compatible with `debian-cloud-sid` spread system.

--- a/spread.yaml
+++ b/spread.yaml
@@ -98,6 +98,7 @@ environment:
     X_SPREAD_MAAS_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_MAAS_RISK_LEVEL:-candidate}")'
     X_SPREAD_SNAPCRAFT_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_SNAPCRAFT_RISK_LEVEL:-stable}")'
     X_SPREAD_DOCKER_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_DOCKER_RISK_LEVEL:-stable}")'
+    X_SPREAD_SALSA_JOB_ID: '$(HOST: echo "${X_SPREAD_SALSA_JOB_ID:-}")'
 exclude:
     - .image-garden
     - .git

--- a/spread/prepare.sh
+++ b/spread/prepare.sh
@@ -13,6 +13,36 @@ fi
 # Show the version of classically packaged snapd.
 snap version | tee snap-version.distro.debug
 
+case "$SPREAD_SYSTEM" in
+debian-cloud-sid)
+	# If requested, download a custom build of snapd from salsa.debian.org
+	# artifact page. An example job is https://salsa.debian.org/debian/snapd/-/jobs/7311035/
+	# from pipeline https://salsa.debian.org/debian/snapd/-/pipelines/838704
+	# This is the "build" job from standard Salsa CI pipeline. The job offers
+	# x86_64 debian packages to install from the debian/output/ directory inside
+	# the zip file that is the artifact transport container.
+	#
+	# The limitation on the system name is because snapd built on Salsa is only
+	# really compatible with Debian unstable (given that it is also built there).
+	if [ -n "$X_SPREAD_SALSA_JOB_ID" ]; then
+		curl \
+			--location \
+			--insecure \
+			--fail \
+			--output /var/tmp/snapd.salsa.zip \
+			https://salsa.debian.org/debian/snapd/-/jobs/"$X_SPREAD_SALSA_JOB_ID"/artifacts/download
+		mkdir -p /var/tmp/snapd.salsa
+		unzip -d /var/tmp/snapd.salsa /var/tmp/snapd.salsa.zip
+		apt install -y \
+			/var/tmp/snapd.salsa/debian/output/snapd_*.deb \
+			/var/tmp/snapd.salsa/debian/output/snap-confine_*.deb
+		rm -rf /var/tmp/snapd.salsa
+		# Show the version of classically updated snapd.
+		snap version | tee snap-version.salsa.debug
+	fi
+	;;
+esac
+
 # Show the list of pre-installed snaps.
 snap list | tee snap-list-preinstalled.debug
 


### PR DESCRIPTION
When X_SPREAD_SALSA_JOB_ID environment variable is set, the GitLab artifact for that job is obtained, and the snapd classic package from that version is installed. This allows running the smoke test pipeline in response to new builds of the snapd Debian packaging.

An example job, at the time of this writing is
https://salsa.debian.org/debian/snapd/-/jobs/7311035

The job corresponds to Debian shared pipeline used by snapd packaging repository. The "build" job builds the package from source and collects the resulting Debian package files as artifacts.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35065