### PR TITLE
Add support for testing CI/CD builds from Bodhi

### DIFF
--- a/.github/workflows/bodhi.yaml
+++ b/.github/workflows/bodhi.yaml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+name: bodhi
+on:
+    workflow_dispatch:
+        inputs:
+            bodhi-advisory-id:
+                description: 'ID of the Fedora update advisory to test'
+                type: choice
+                required: true
+                options:
+                    - fedora-cloud-41
+                    - fedora-cloud-42
+                    - centos-cloud-9
+                    - centos-cloud-10
+            garden-system:
+                description: 'System to test against (fedora-cloud-XX)'
+                type: string
+                required: true
+            snapd-risk-level:
+                description: 'Store risk level of the snapd snap'
+                type: string
+                default: 'beta'
+                required: true
+            lxd-risk-level:
+                description: 'Store risk level of the LXD snap'
+                type: string
+                default: 'candidate'
+                required: true
+            maas-risk-level:
+                description: 'Store risk level of the MAAS snap'
+                type: string
+                default: 'candidate'
+                required: true
+            snapcraft-risk-level:
+                description: 'Store risk level of the snapcraft snap'
+                type: string
+                default: 'stable'
+                required: true
+            docker-risk-level:
+                description: 'Store risk level of the docker snap'
+                type: string
+                default: stable
+            image-garden-channel:
+                description: 'Store channel of the image-garden snap'
+                type: string
+                default: 'latest/edge'
+                required: true
+jobs:
+    spread:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              # This is essential for git restore-mtime to work correctly.
+              with:
+                fetch-depth: 0
+            - name: Cache downloaded snaps
+              uses: actions/cache@v4
+              with:
+                path: .image-garden/cache-*/snaps
+                key: snaps
+            - name: Set environment variables for spread
+              run: |
+                # Export variables that spread picks up from the host.
+                echo X_SPREAD_SNAPD_RISK_LEVEL="${{ inputs.snapd-risk-level || 'beta' }}" >> $GITHUB_ENV
+                echo X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_MAAS_RISK_LEVEL="${{ inputs.maas-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_SNAPCRAFT_RISK_LEVEL="${{ inputs.snapcraft-risk-level || 'stable' }}" >> $GITHUB_ENV
+                echo X_SPREAD_DOCKER_RISK_LEVEL="${{ inputs.docker-risk-level || 'stable' }}" >> $GITHUB_ENV
+                echo X_SPREAD_BODHI_ADVISORY_ID="${{ inputs.bodhi-advisory-id || '' }}" >> $GITHUB_ENV
+            - name: Run integration tests
+              uses: zyga/image-garden-action@85a3d79c9d1e1628d7b0bad081b3a3463c2819a3
+              with:
+                garden-system: ${{inputs.garden-system }}
+                image-garden-channel: ${{ inputs.image-garden-channel }}

--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ https://salsa.debian.org/debian/snapd and either invoke the GitHub workflow
 `X_SPREAD_SALSA_JOB_ID=` environment variable set.
 
 Note that this is only compatible with `debian-cloud-sid` spread system.
+
+## Testing builds from https://bodhi.fedoraproject.org/
+
+Grab the advisory number from the Fedora update system (e.g.
+`FEDORA-2025-737127f363`) and either invoke the GitHub workflow passing the ID
+or run spread locally with `X_SPREAD_BODHI_ADVISORY_ID=` environment variable
+set.
+
+Note that the advisory is only compatible with a given release of Fedora or
+EPEL, so you must be careful in selecting the system to pair it with.

--- a/spread.yaml
+++ b/spread.yaml
@@ -99,6 +99,7 @@ environment:
     X_SPREAD_SNAPCRAFT_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_SNAPCRAFT_RISK_LEVEL:-stable}")'
     X_SPREAD_DOCKER_RISK_LEVEL: '$(HOST: echo "${X_SPREAD_DOCKER_RISK_LEVEL:-stable}")'
     X_SPREAD_SALSA_JOB_ID: '$(HOST: echo "${X_SPREAD_SALSA_JOB_ID:-}")'
+    X_SPREAD_BODHI_ADVISORY_ID: '$(HOST: echo "${X_SPREAD_BODHI_ADVISORY_ID:-}")'
 exclude:
     - .image-garden
     - .git

--- a/spread/prepare.sh
+++ b/spread/prepare.sh
@@ -41,6 +41,15 @@ debian-cloud-sid)
 		snap version | tee snap-version.salsa.debug
 	fi
 	;;
+fedora-* | centos-*)
+	# If requested, download and install a custom build of snapd from the
+	# Fedora update system, Bodhi.
+	if [ -n "$X_SPREAD_BODHI_ADVISORY_ID" ]; then
+		dnf upgrade --refresh --advisory="$X_SPREAD_BODHI_ADVISORY_ID"
+		# Show the version of classically updated snapd.
+		snap version | tee snap-version.bodhi.debug
+	fi
+	;;
 esac
 
 # Show the list of pre-installed snaps.


### PR DESCRIPTION
When X_SPREAD_BODHI_ADVISORY_ID environment variable is set, the system under test is updated to the version of snapd contained in the advisory. This allows running the smoke test pipeline in response to new updates proposed to Fedora and EPEL.

An example update advisory updating Fedora 42 to snapd 2.68.3 is https://bodhi.fedoraproject.org/updates/FEDORA-2025-737127f363

Note that due to the nature of the tooling, only more recent version of snapd, than the one available in the distribution, can be tested this way.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35064