### PR TITLE
Re-enable snapcraft test on most systems

### DIFF
--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -16,8 +16,6 @@ execute: |
     ( cd test-snapd-smoke && snapcraft -v )
     snap install --dangerous ./test-snapd-smoke/test-snapd-smoke_1.0.0_*.snap
     snap run test-snapd-smoke | MATCH "I'm a snap!"
-# This task fails because LXD container created by snapcraft cannot access network.
-manual: true
 debug: |
     snap run lxd.lxc project list || true
     snap run lxd.lxc list --project=snapcraft || true

--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -7,7 +7,7 @@ environment:
     LXD_TRACK/latest: latest
 execute: |
     snap run snapcraft --help 2>&1 | MATCH 'Package, distribute, and update snaps for Linux and IoT'
-    cd test-snapd-smoke && snapcraft -v
+    ( cd test-snapd-smoke && snapcraft -v )
     snap install --dangerous ./test-snapd-smoke/test-snapd-smoke_1.0.0_*.snap
     snap run test-snapd-smoke | MATCH "I'm a snap!"
 # This task fails because LXD container created by snapcraft cannot access network.

--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -28,30 +28,6 @@ prepare: |
     snap run lxd waitready
     # Initialize LXD storage and networking with default settings.
     snap run lxd init --auto
-    # Configure firewall to allow network traffic.
-    # https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/
-    snap run lxd.lxc network set lxdbr0 ipv4.firewall false
-    snap run lxd.lxc network set lxdbr0 ipv4.nat false
-    snap run lxd.lxc network set lxdbr0 ipv6.address ""
-    snap run lxd.lxc network set lxdbr0 ipv6.firewall false
-    snap run lxd.lxc network set lxdbr0 ipv6.nat false
-    if command -v firewall-cmd; then
-        firewall-cmd --add-interface=lxdbr0 --zone=trusted --permanent
-        firewall-cmd --reload
-    fi
-    if command -v ufw; then
-        ufw allow in on lxdbr0
-        ufw route allow in on lxdbr0
-        ufw route allow out on lxdbr0
-    fi
-    if command -v iptables; then
-        iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT || true
-        iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
-    fi
-    if command -v ip6tables; then
-        ip6tables -I DOCKER-USER -i lxdbr0 -j ACCEPT || true
-        ip6tables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
-    fi
     # Install snapcraft for building a snap.
     snap-install --classic snapcraft latest/"${X_SPREAD_SNAPCRAFT_RISK_LEVEL}"
 restore: |

--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -7,6 +7,10 @@ environment:
     LXD_TRACK/latest: latest
 kill-timeout: 5m
 warn-timeout: 3m
+systems:
+    - -amazon-cloud-2
+    - -debian-cloud-11
+    - -ubuntu-cloud-20.04
 execute: |
     snap run snapcraft --help 2>&1 | MATCH 'Package, distribute, and update snaps for Linux and IoT'
     ( cd test-snapd-smoke && snapcraft -v )

--- a/tests/server/snapcraft/task.yaml
+++ b/tests/server/snapcraft/task.yaml
@@ -5,6 +5,8 @@ environment:
     LXD_TRACK/5_21: "5.21"
     LXD_TRACK/6: 6
     LXD_TRACK/latest: latest
+kill-timeout: 5m
+warn-timeout: 3m
 execute: |
     snap run snapcraft --help 2>&1 | MATCH 'Package, distribute, and update snaps for Linux and IoT'
     ( cd test-snapd-smoke && snapcraft -v )


### PR DESCRIPTION
Three systems are still disabled to be investigated separately. In each case the error is related to FUSE.
```
error: system does not fully support snapd: cannot mount squashfs image using "fuse.snapfuse": fuse: failed to exec fusermount3: No such file or directory
```

Remove a bit of magic cruft related to LXD and firewalls that does not seem relevant.