### PR TITLE
Add dynamic run names to testing workflows

### DIFF
--- a/.github/workflows/arch.yaml
+++ b/.github/workflows/arch.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Canonical Ltd.
 name: arch
+run-name: Test Arch Pull Request ${{ inputs.arch-repo-pr }}
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/bodhi.yaml
+++ b/.github/workflows/bodhi.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Canonical Ltd.
 name: bodhi
+run-name: Test ${{ inputs.bodhi-advisory-id }} on ${{ inputs.garden-system }}
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/salsa.yaml
+++ b/.github/workflows/salsa.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Canonical Ltd.
 name: salsa
+run-name: Test Salsa job ${{ inputs.salsa-job-id }}
 on:
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
Those improve usability when running tests for a release, as each run has a distinct name that indicates what is being tested.