### PR TITLE
Add support for testing Amazon Linux 2023/2 repository tarballs

### DIFF
--- a/.github/workflows/amazon.yaml
+++ b/.github/workflows/amazon.yaml
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Canonical Ltd.
+name: opensuse
+run-name: Test Amazon Linux package from an action artifact in https://github.com/bboozzoo/snapd-amazon-linux
+on:
+    workflow_dispatch:
+        inputs:
+            amazon-variant:
+                description: "Amazon Linux variant"
+                type: string
+                default: "amazonlinux-cloud-2023"
+            artifact-repo:
+                # typically https://github.com/bboozzoo/snapd-amazon-linux
+                description: "Github repository which produced artifacts, format: OWNER/NAME"
+                type: string
+                default: "bboozzoo/snapd-amazon-linux"
+            artifact-rep-run-id:
+                description: "Github action run ID in the artifact repository"
+                required: true
+            snapd-risk-level:
+                description: "Store risk level of the snapd snap"
+                type: choice
+                default: beta
+                required: true
+                options:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+            lxd-risk-level:
+                description: "Store risk level of the LXD snap"
+                type: choice
+                default: candidate
+                required: true
+                options:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+            maas-risk-level:
+                description: "Store risk level of the MAAS snap"
+                type: choice
+                default: candidate
+                required: true
+                options:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+            snapcraft-risk-level:
+                description: "Store risk level of the snapcraft snap"
+                type: choice
+                default: stable
+                required: true
+                options:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+            docker-risk-level:
+                description: "Store risk level of the docker snap"
+                type: choice
+                default: stable
+                required: true
+                options:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+            image-garden-channel:
+                description: "Store channel of the image-garden snap"
+                type: string
+                default: "latest/edge"
+                required: true
+env:
+    GH_TOKEN: ${{ github.token }}
+
+jobs:
+    spread:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              # This is essential for git restore-mtime to work correctly.
+              with:
+                fetch-depth: 0
+            - name: Cache downloaded snaps
+              uses: actions/cache@v4
+              with:
+                path: .image-garden/cache-*/snaps
+                key: snaps
+            - name: Download artifacts
+              run: |
+                # downloads and extracts the artifacts
+                gh run download -R "${{ inputs.artifact-repo }}" "${{ inputs.artifact-repo-run-id }}"
+                # we should get the following files:
+                # repo-tarball-amazonlinux-2/amazon-linux-2-repo.tar.xz
+                # repo-tarball-amazonlinux-2023/amazon-linux-2023-repo.tar.xz
+                case "${{ inputs.amazon-variant }}" in
+                amazonlinux-cloud-2023*)
+                    repo_file=./repo-tarball-amazonlinux-2023/amazon-linux-2023-repo.tar.xz
+                    ;;
+                amazonlinux-cloud-2)
+                    repo_file=./repo-tarball-amazonlinux-2/amazon-linux-2-repo.tar.xz
+                    ;;
+                *)
+                    echo "unexpected variant?"
+                    exit 1
+                    ;;
+                esac
+                # XXX use relative repo file path, which remains true when used
+                # inside the spread allocated system with the contents of
+                # current directory uploaded as input
+                echo X_SPREAD_AMAZON_REPO_FILE="$repo_file" >> $GITHUB_ENV
+            - name: Set environment variables for spread
+              run: |
+                # Export other variables that spread picks up from the host.
+                echo X_SPREAD_SNAPD_RISK_LEVEL="${{ inputs.snapd-risk-level || 'beta' }}" >> $GITHUB_ENV
+                echo X_SPREAD_LXD_RISK_LEVEL="${{ inputs.lxd-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_MAAS_RISK_LEVEL="${{ inputs.maas-risk-level || 'candidate' }}" >> $GITHUB_ENV
+                echo X_SPREAD_SNAPCRAFT_RISK_LEVEL="${{ inputs.snapcraft-risk-level || 'stable' }}" >> $GITHUB_ENV
+                echo X_SPREAD_DOCKER_RISK_LEVEL="${{ inputs.docker-risk-level || 'stable' }}" >> $GITHUB_ENV
+            - name: Run integration tests
+              uses: zyga/image-garden-action@v0.1
+              with:
+                garden-system: ${{ inputs.amazon-variant }}
+                snapd-channel: latest/edge
+                image-garden-channel: ${{ inputs.image-garden-channel || 'latest/edge' }}
+                # only server specific tests
+                spread-tasks: "tests/server/..."

--- a/README.md
+++ b/README.md
@@ -60,8 +60,23 @@ with [aurpublish](https://github.com/eli-schwartz/aurpublish), you can set
 `X_SPREAD_ARCH_REPO_SUBDIR` to point to the directory where snapd packaging
 files are located.
 
-## Testing snapd openSUSE Packages
+## Testing snapd openSUSE packages
 
 By default snapd will be installed from the `system:snappy` OBS project. One can
 set `X_SPREAD_OPENSUSE_OBS_PROJECT` to run tests with snapd package from a
-custom OBS project, e.g `X_SPREAD_OPENSUSE_OBS_PROJECT=home:my_user_on_obs:branches:system:snappy`.
+custom OBS project, e.g. `X_SPREAD_OPENSUSE_OBS_PROJECT=home:my_user_on_obs:branches:system:snappy`.
+
+## Testing Amazon Linux packages
+
+By default snapd will be installed from a community repository hosted at
+https://bboozzoo.github.io/snapd-amazon-linux.
+
+The artifacts provided in that repository are built using tooling from
+https://github.com/bboozzoo/snapd-amazon-linux. The repository tarballs
+generated with the tooling can be directly consumed by the smoke test suite by
+setting `X_SPREAD_AMAZON_REPO_FILE` to the relative path of the `*.tar.xz*`
+repository tarball. For example:
+
+```sh
+X_SPREAD_AMAZON_REPO_FILE=./amazon-linux-2-repo.tar.xz  spread -v garden:amazonlinux-cloud-2023:tests/server/...
+```

--- a/spread.yaml
+++ b/spread.yaml
@@ -103,6 +103,7 @@ environment:
     X_SPREAD_ARCH_SNAPD_PR: '$(HOST: echo "${X_SPREAD_ARCH_SNAPD_PR:-}")'
     X_SPREAD_ARCH_SNAPD_REPO_SUBDIR: '$(HOST: echo "${X_SPREAD_ARCH_SNAPD_REPO_SUBDIR:-}")'
     X_SPREAD_OPENSUSE_OBS_PROJECT: '$(HOST: echo "${X_SPREAD_OPENSUSE_OBS_PROJECT:-}")'
+    X_SPREAD_AMAZON_REPO_FILE: '$(HOST: echo "${X_SPREAD_AMAZON_REPO_FILE:-}")'
 exclude:
     - .image-garden
     - .git

--- a/spread/prepare.sh
+++ b/spread/prepare.sh
@@ -87,6 +87,25 @@ opensuse-*)
 		fi
 	fi
 	;;
+amazonlinux-*)
+	if [ -n "$X_SPREAD_AMAZON_REPO_FILE" ]; then
+		rm -v /etc/yum.repos.d/snapd.repo
+		# this contains a directory named repo containing snapd.repo file
+		tar xvf "$X_SPREAD_AMAZON_REPO_FILE"
+		# update the repo to point to the local directory
+		sed -e "s#^baseurl=.*\(\$basearch\|sources\)#baseurl=file://$PWD/repo/\1#" <repo/snapd.repo >/etc/yum.repos.d/snapd.repo
+		# since snapd is already installed this should sync snapd to whatever
+		# version is available in the repository
+		case "$SPREAD_SYSTEM" in
+		amazonlinux-cloud-2023*)
+			dnf distro-sync -y
+			;;
+		*)
+			yum distro-sync -y
+			;;
+		esac
+	fi
+	;;
 esac
 
 # Show the list of pre-installed snaps.


### PR DESCRIPTION
Related: [SNAPDENG-35170](https://warthogs.atlassian.net/browse/SNAPDENG-35170)

[SNAPDENG-35170]: https://warthogs.atlassian.net/browse/SNAPDENG-35170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ