### PR TITLE
opensuse: use package default snap mount directory

### DIFF
--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -80,10 +80,11 @@ on:
                 description: "Snap mount directory"
                 type: choice
                 options:
+                    # default - package default
                     - default
                     - /snap
                     - /var/lib/snapd/snap
-                default: /snap
+                default: default
 
 jobs:
     prepare-docker-image:

--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -77,7 +77,7 @@ on:
                 type: boolean
                 default: false
             opensuse-snap-mount-dir:
-                description: "Snap mount directory"
+                description: "Snap mount directory (use 'default' for package installation default)"
                 type: choice
                 options:
                     # default - package default

--- a/spread.yaml
+++ b/spread.yaml
@@ -132,6 +132,7 @@ environment:
     # supported mount directories on openSUSE, possible choices are:
     # - /snap
     # - /var/lib/snapd/snap
+    # - default - which is the package default
     X_SPREAD_OPENSUSE_MOUNT_DIR: '$(HOST: echo "${X_SPREAD_OPENSUSE_MOUNT_DIR:-default}")'
     X_SPREAD_AMAZON_REPO_FILE: '$(HOST: echo "${X_SPREAD_AMAZON_REPO_FILE:-}")'
     X_SPREAD_LOCAL_SNAPD_PKG: '$(HOST: echo "${X_SPREAD_LOCAL_SNAPD_PKG:-}")'


### PR DESCRIPTION
Use package default snap mount directory in openSUSE tests